### PR TITLE
#110: Display week day and calendar week in status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ See [Release](https://github.com/itsallcode/white-rabbit/releases/tag/v1.6.0) / 
 
 ### Added
 
+* [#110](https://github.com/itsallcode/white-rabbit/issues/110): Display current date incl. day of week and number of calendar week (ISO).
+  * Important: to show the correct calendar week, enter a locale with the country in `~/.whiterabbit.properties`, e.g. `locale = de-DE` or `en-GB`.
 * [#113](https://github.com/itsallcode/white-rabbit/issues/113): Show tooltips for table column headers with full label.
 * [#108](https://github.com/itsallcode/white-rabbit/issues/108): Support more conventions to enter time, e.g. 1200 for 12:00 or 1 for 01:00.
 * [#121](https://github.com/itsallcode/white-rabbit/pull/121): Allow using plugins via webstart.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ See [Release](https://github.com/itsallcode/white-rabbit/releases/tag/v1.6.0) / 
 
 ### Added
 
-* [#110](https://github.com/itsallcode/white-rabbit/issues/110): Display current date incl. day of week and number of calendar week (ISO).
+* [#110](https://github.com/itsallcode/white-rabbit/issues/110) / [PR #145](https://github.com/itsallcode/white-rabbit/pull/145): Display current date incl. day of week and number of calendar week (ISO).
   * Important: to show the correct calendar week, enter a locale with the country in `~/.whiterabbit.properties`, e.g. `locale = de-DE` or `en-GB`.
 * [#113](https://github.com/itsallcode/white-rabbit/issues/113): Show tooltips for table column headers with full label.
 * [#108](https://github.com/itsallcode/white-rabbit/issues/108): Support more conventions to enter time, e.g. 1200 for 12:00 or 1 for 01:00.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ Restart WhiteRabbit after changing the configuration file.
 
 #### <a name="optional_config"></a>Optional configuration settings
 
-* `locale`: format of date and time values, e.g. `de` or `en`. Default: system locale.
+* `locale`: format of date and time values as an [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag), e.g. `de`, `de-DE` or `en-GB`. Default: system locale.
+  * Note: enter a locale with country code (e.g. `de-DE`) to get correct formatting of date and time, e.g. the calendar week.
 * `current_working_time_per_day`: custom working time per day differing from the default of 8 hours. Format: see [Duration.parse()](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence)), e.g. `PT5H` for 5 hours or `PT5H30M` for 5 hours and 30 minutes. This setting will only affect the future.
 
 #### <a name="project_config"></a>Project configuration

--- a/jfxui/src/uiTest/java/org/itsallcode/whiterabbit/jfxui/JavaFxAppUiTest.java
+++ b/jfxui/src/uiTest/java/org/itsallcode/whiterabbit/jfxui/JavaFxAppUiTest.java
@@ -43,19 +43,19 @@ class JavaFxAppUiTest extends JavaFxAppUiTestBase
         final Labeled overtimeLabel = robot.lookup("#overtime-label").queryLabeled();
 
         assertAll(
-                () -> Assertions.assertThat(timeLabel).hasText("03.12.07, 11:15:30"),
+                () -> Assertions.assertThat(timeLabel).hasText("Mo., 03.12.2007 CW49, 11:15:30"),
                 () -> Assertions.assertThat(overtimeLabel)
                         .hasText("Overtime previous month: 00:00, this month: 00:00, total: 00:00"));
 
         time().tickSecond();
         assertAll(
-                () -> Assertions.assertThat(timeLabel).hasText("03.12.07, 11:15:31"),
+                () -> Assertions.assertThat(timeLabel).hasText("Mo., 03.12.2007 CW49, 11:15:31"),
                 () -> Assertions.assertThat(overtimeLabel)
                         .hasText("Overtime previous month: 00:00, this month: 00:00, total: 00:00"));
 
         time().tickMinute();
         assertAll(
-                () -> Assertions.assertThat(timeLabel).hasText("03.12.07, 11:16:31"),
+                () -> Assertions.assertThat(timeLabel).hasText("Mo., 03.12.2007 CW49, 11:16:31"),
                 () -> Assertions.assertThat(overtimeLabel)
                         .hasText("Overtime previous month: 00:00, this month: -08:00, total: -08:00"));
 
@@ -71,19 +71,19 @@ class JavaFxAppUiTest extends JavaFxAppUiTestBase
         final Labeled overtimeLabel = robot.lookup("#overtime-label").queryLabeled();
 
         assertAll(
-                () -> Assertions.assertThat(timeLabel).hasText("03.12.07, 11:15:30"),
+                () -> Assertions.assertThat(timeLabel).hasText("Mo., 03.12.2007 CW49, 11:15:30"),
                 () -> Assertions.assertThat(overtimeLabel)
                         .hasText("Overtime previous month: 00:00, this month: 00:00, total: 00:00"));
 
         time().tickSecond();
         assertAll(
-                () -> Assertions.assertThat(timeLabel).hasText("03.12.07, 11:15:31"),
+                () -> Assertions.assertThat(timeLabel).hasText("Mo., 03.12.2007 CW49, 11:15:31"),
                 () -> Assertions.assertThat(overtimeLabel)
                         .hasText("Overtime previous month: 00:00, this month: 00:00, total: 00:00"));
 
         time().tickMinute();
         assertAll(
-                () -> Assertions.assertThat(timeLabel).hasText("03.12.07, 11:16:31"),
+                () -> Assertions.assertThat(timeLabel).hasText("Mo., 03.12.2007 CW49, 11:16:31"),
                 () -> Assertions.assertThat(overtimeLabel)
                         .hasText("Overtime previous month: 00:00, this month: -08:00, total: -08:00"));
 

--- a/logic/src/main/java/org/itsallcode/whiterabbit/logic/service/FormatterService.java
+++ b/logic/src/main/java/org/itsallcode/whiterabbit/logic/service/FormatterService.java
@@ -6,7 +6,6 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.time.format.FormatStyle;
 import java.util.Locale;
 
 public class FormatterService
@@ -19,8 +18,9 @@ public class FormatterService
     {
         this.locale = locale;
         this.timeZoneId = timeZoneId;
-        this.dateTimeFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT, FormatStyle.MEDIUM)
-                .withLocale(locale).withZone(timeZoneId);
+        this.dateTimeFormatter = DateTimeFormatter.ofPattern("EE, dd.MM.yyyy 'CW'ww, HH:mm:ss")
+            .withZone(timeZoneId)
+            .withLocale(locale);
     }
 
     public String format(Duration duration)

--- a/logic/src/test/java/org/itsallcode/whiterabbit/logic/service/FormatterServiceTest.java
+++ b/logic/src/test/java/org/itsallcode/whiterabbit/logic/service/FormatterServiceTest.java
@@ -17,7 +17,7 @@ class FormatterServiceTest
     @BeforeEach
     void setUp()
     {
-        formatter = new FormatterService(Locale.GERMAN, ZoneId.of("Europe/Berlin"));
+        formatter = new FormatterService(Locale.GERMANY, ZoneId.of("Europe/Berlin"));
     }
 
     @Test
@@ -30,6 +30,6 @@ class FormatterServiceTest
     void testFormatDateAndTime()
     {
         assertThat(formatter.formatDateAndTime(Instant.parse("2007-12-03T10:15:30.00Z")))
-                .isEqualTo("03.12.07, 11:15:30");
+                .isEqualTo("Mo., 03.12.2007 CW49, 11:15:30");
     }
 }


### PR DESCRIPTION
Closes #110 

Important: to show the correct calendar week, enter a locale with the country in `~/.whiterabbit.properties`, e.g. `locale = de-DE` or `en-GB`.