### PR TITLE
Refactor plugin manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 See [Release](https://github.com/itsallcode/white-rabbit/releases/tag/v1.7.0) / [Milestone](https://github.com/itsallcode/white-rabbit/milestone/9?closed=1)
 
+### Breaking change
+
+* [#192](https://github.com/itsallcode/white-rabbit/pull/192): Simplify the `Plugin` interface by returning an empty `Optional` instead of null or throwing an exception.
+  * This requires adapting third party plugins and rebuilding plugins installed to `~/.whiterabbit/plugins/`.
+
 ### Fixed
 
 * [#191](https://github.com/itsallcode/white-rabbit/pull/191): Starting WR with all plugins enabled failed with exception `IllegalStateException: Found multiple plugins supporting org.itsallcode.whiterabbit.api.features.MonthDataStorage`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 See [Release](https://github.com/itsallcode/white-rabbit/releases/tag/v1.7.0) / [Milestone](https://github.com/itsallcode/white-rabbit/milestone/9?closed=1)
 
+### Fixed
+
+* [#191](https://github.com/itsallcode/white-rabbit/pull/191): Starting WR with all plugins enabled failed with exception `IllegalStateException: Found multiple plugins supporting org.itsallcode.whiterabbit.api.features.MonthDataStorage`.
+
 ### Added
 
 * [#158](https://github.com/itsallcode/white-rabbit/issues/158): PMSmart plugin: Support optional configuration  `pmsmart.transfer.comments` to skip transfer of comments.

--- a/api/src/main/java/org/itsallcode/whiterabbit/api/AbstractPlugin.java
+++ b/api/src/main/java/org/itsallcode/whiterabbit/api/AbstractPlugin.java
@@ -37,7 +37,7 @@ public abstract class AbstractPlugin<S extends PluginFeature> implements Plugin
     @Override
     public boolean supports(Class<? extends PluginFeature> featureType)
     {
-        return featureType.isAssignableFrom(featureType);
+        return this.featureType.isAssignableFrom(featureType);
     }
 
     protected abstract S createInstance();
@@ -45,7 +45,7 @@ public abstract class AbstractPlugin<S extends PluginFeature> implements Plugin
     @Override
     public <T extends PluginFeature> Optional<T> getFeature(Class<T> featureType)
     {
-        if (featureType.isAssignableFrom(this.featureType))
+        if (this.supports(featureType))
         {
             return Optional.of(featureType.cast(createInstance()));
         }

--- a/api/src/main/java/org/itsallcode/whiterabbit/api/AbstractPlugin.java
+++ b/api/src/main/java/org/itsallcode/whiterabbit/api/AbstractPlugin.java
@@ -1,5 +1,7 @@
 package org.itsallcode.whiterabbit.api;
 
+import java.util.Optional;
+
 import org.itsallcode.whiterabbit.api.features.PluginFeature;
 
 public abstract class AbstractPlugin<S extends PluginFeature> implements Plugin
@@ -41,12 +43,12 @@ public abstract class AbstractPlugin<S extends PluginFeature> implements Plugin
     protected abstract S createInstance();
 
     @Override
-    public <T extends PluginFeature> T getFeature(Class<T> featureType)
+    public <T extends PluginFeature> Optional<T> getFeature(Class<T> featureType)
     {
         if (featureType.isAssignableFrom(this.featureType))
         {
-            return featureType.cast(createInstance());
+            return Optional.of(featureType.cast(createInstance()));
         }
-        throw new IllegalArgumentException("Feature " + featureType.getName() + " not supported by plugin " + getId());
+        return Optional.empty();
     }
 }

--- a/api/src/main/java/org/itsallcode/whiterabbit/api/Plugin.java
+++ b/api/src/main/java/org/itsallcode/whiterabbit/api/Plugin.java
@@ -1,5 +1,7 @@
 package org.itsallcode.whiterabbit.api;
 
+import java.util.Optional;
+
 import org.itsallcode.whiterabbit.api.features.MonthDataStorage;
 import org.itsallcode.whiterabbit.api.features.PluginFeature;
 import org.itsallcode.whiterabbit.api.features.ProjectReportExporter;
@@ -51,10 +53,10 @@ public interface Plugin
      *            the feature type.
      * @param <T>
      *            the type of the feature.
-     * @return the instance of the given feature. May return <code>null</code>
-     *         or throw an exception if the feature is not supported.
+     * @return the instance of the given feature or an empty {@link Optional} if
+     *         the feature is not supported.
      */
-    <T extends PluginFeature> T getFeature(Class<T> featureType);
+    <T extends PluginFeature> Optional<T> getFeature(Class<T> featureType);
 
     /**
      * Called before closing the plugin. The plugin should cleanup any resources

--- a/api/src/main/java/org/itsallcode/whiterabbit/api/Plugin.java
+++ b/api/src/main/java/org/itsallcode/whiterabbit/api/Plugin.java
@@ -2,6 +2,7 @@ package org.itsallcode.whiterabbit.api;
 
 import java.util.Optional;
 
+import org.itsallcode.whiterabbit.api.features.Holidays;
 import org.itsallcode.whiterabbit.api.features.MonthDataStorage;
 import org.itsallcode.whiterabbit.api.features.PluginFeature;
 import org.itsallcode.whiterabbit.api.features.ProjectReportExporter;
@@ -16,6 +17,7 @@ import org.itsallcode.whiterabbit.api.features.ProjectReportExporter;
  * <ul>
  * <li>{@link ProjectReportExporter}</li>
  * <li>{@link MonthDataStorage}</li>
+ * <li>{@link Holidays}</li>
  * </ul>
  */
 public interface Plugin

--- a/api/src/test/java/org/itsallcode/whiterabbit/api/AbstractPluginTest.java
+++ b/api/src/test/java/org/itsallcode/whiterabbit/api/AbstractPluginTest.java
@@ -1,7 +1,6 @@
 package org.itsallcode.whiterabbit.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.itsallcode.whiterabbit.api.features.PluginFeature;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,17 +38,15 @@ class AbstractPluginTest
     }
 
     @Test
-    void gettingUnsupportedFeatureThrowsException()
+    void gettingUnsupportedFeatureReturnsEmptyOptional()
     {
-        assertThatThrownBy(() -> plugin.getFeature(UnsupportedFeature.class))
-                .isInstanceOf(IllegalArgumentException.class).hasMessage(
-                        "Feature " + UnsupportedFeature.class.getName() + " not supported by plugin " + PLUGIN_ID);
+        assertThat(plugin.getFeature(UnsupportedFeature.class)).isEmpty();
     }
 
     @Test
     void gettingSupportedFeatureWorks()
     {
-        assertThat(plugin.getFeature(SupportedFeature.class)).isSameAs(supportedFeatureMock);
+        assertThat(plugin.getFeature(SupportedFeature.class)).isPresent().containsSame(supportedFeatureMock);
     }
 
     @Test

--- a/api/src/test/java/org/itsallcode/whiterabbit/api/AbstractPluginTest.java
+++ b/api/src/test/java/org/itsallcode/whiterabbit/api/AbstractPluginTest.java
@@ -1,0 +1,84 @@
+package org.itsallcode.whiterabbit.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.itsallcode.whiterabbit.api.features.PluginFeature;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractPluginTest
+{
+    private static final String PLUGIN_ID = "testing-plugin";
+
+    @Mock
+    SupportedFeature supportedFeatureMock;
+
+    private TestingAbstractPlugin plugin;
+
+    @BeforeEach
+    void setUp()
+    {
+        plugin = new TestingAbstractPlugin();
+    }
+
+    @Test
+    void supportsReturnsTrueForSupportedFeature()
+    {
+        assertThat(plugin.supports(SupportedFeature.class)).isTrue();
+    }
+
+    @Test
+    void supportsReturnsFalseForUnsupportedFeature()
+    {
+        assertThat(plugin.supports(UnsupportedFeature.class)).isFalse();
+    }
+
+    @Test
+    void gettingUnsupportedFeatureThrowsException()
+    {
+        assertThatThrownBy(() -> plugin.getFeature(UnsupportedFeature.class))
+                .isInstanceOf(IllegalArgumentException.class).hasMessage(
+                        "Feature " + UnsupportedFeature.class.getName() + " not supported by plugin " + PLUGIN_ID);
+    }
+
+    @Test
+    void gettingSupportedFeatureWorks()
+    {
+        assertThat(plugin.getFeature(SupportedFeature.class)).isSameAs(supportedFeatureMock);
+    }
+
+    @Test
+    void getPluginId()
+    {
+        assertThat(plugin.getId()).isEqualTo(PLUGIN_ID);
+    }
+
+    private interface SupportedFeature extends PluginFeature
+    {
+
+    }
+
+    private interface UnsupportedFeature extends PluginFeature
+    {
+
+    }
+
+    private class TestingAbstractPlugin extends AbstractPlugin<SupportedFeature>
+    {
+        protected TestingAbstractPlugin()
+        {
+            super(PLUGIN_ID, SupportedFeature.class);
+        }
+
+        @Override
+        protected SupportedFeature createInstance()
+        {
+            return supportedFeatureMock;
+        }
+    }
+}

--- a/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/table/days/DayRecordPropertyAdapter.java
+++ b/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/table/days/DayRecordPropertyAdapter.java
@@ -88,7 +88,7 @@ public class DayRecordPropertyAdapter extends RecordPropertyAdapter<DayRecord>
         this.tableRow = newTableRow;
         if (date.get() != null && tableRow.getIndex() + 1 != date.get().getDayOfMonth())
         {
-            LOG.warn("Trying to set invalid row #{} for date {}.", tableRow.getIndex(), date.get());
+            LOG.trace("Trying to set invalid row #{} for date {}.", tableRow.getIndex(), date.get());
             return;
         }
         LOG.trace("Setting table row #{} for day {}", newTableRow.getIndex(), date.get());

--- a/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/ui/ProjectReportViewer.java
+++ b/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/ui/ProjectReportViewer.java
@@ -22,7 +22,7 @@ import org.itsallcode.whiterabbit.jfxui.ui.widget.ProgressDialog.DialogProgressM
 import org.itsallcode.whiterabbit.jfxui.ui.widget.ReportWindow;
 import org.itsallcode.whiterabbit.jfxui.uistate.UiStateService;
 import org.itsallcode.whiterabbit.logic.service.AppService;
-import org.itsallcode.whiterabbit.logic.service.plugin.PluginWrapper;
+import org.itsallcode.whiterabbit.logic.service.plugin.AppPlugin;
 import org.itsallcode.whiterabbit.logic.service.project.ProjectImpl;
 
 import javafx.event.ActionEvent;
@@ -73,14 +73,14 @@ public class ProjectReportViewer
                 .toArray(Node[]::new);
     }
 
-    private Button createExportButton(PluginWrapper plugin)
+    private Button createExportButton(AppPlugin plugin)
     {
         final String pluginId = plugin.getId();
         final EventHandler<ActionEvent> action = e -> exportReport(plugin);
         return UiWidget.button(pluginId + "-export-button", "Export to " + pluginId, action);
     }
 
-    private void exportReport(PluginWrapper plugin)
+    private void exportReport(AppPlugin plugin)
     {
         final var projectReportExporter = plugin.getFeature(ProjectReportExporter.class)
                 .orElseThrow(() -> new IllegalStateException(

--- a/jfxui/src/uiTest/java/org/itsallcode/whiterabbit/jfxui/testutil/UiTestDummyPlugin.java
+++ b/jfxui/src/uiTest/java/org/itsallcode/whiterabbit/jfxui/testutil/UiTestDummyPlugin.java
@@ -2,6 +2,8 @@ package org.itsallcode.whiterabbit.jfxui.testutil;
 
 import static org.mockito.Mockito.mock;
 
+import java.util.Optional;
+
 import org.itsallcode.whiterabbit.api.Plugin;
 import org.itsallcode.whiterabbit.api.PluginConfiguration;
 import org.itsallcode.whiterabbit.api.features.PluginFeature;
@@ -29,14 +31,13 @@ public class UiTestDummyPlugin implements Plugin
     }
 
     @Override
-    public <T extends PluginFeature> T getFeature(Class<T> featureType)
+    public <T extends PluginFeature> Optional<T> getFeature(Class<T> featureType)
     {
-        return mock(featureType);
+        return Optional.of(mock(featureType));
     }
 
     @Override
     public void close()
     {
-
     }
 }

--- a/logic/src/main/java/org/itsallcode/whiterabbit/logic/service/AppService.java
+++ b/logic/src/main/java/org/itsallcode/whiterabbit/logic/service/AppService.java
@@ -122,7 +122,7 @@ public class AppService implements Closeable
 
     private static MonthDataStorage createMonthDataStorage(final Config config, final PluginManager pluginManager)
     {
-        final Optional<MonthDataStorage> dataStorage = pluginManager.getMonthDataStorage();
+        final Optional<MonthDataStorage> dataStorage = pluginManager.getUniqueFeature(MonthDataStorage.class);
         if (dataStorage.isPresent())
         {
             LOG.info("Using storage plugin {}", dataStorage.get().getClass().getName());

--- a/logic/src/main/java/org/itsallcode/whiterabbit/logic/service/plugin/AppPlugin.java
+++ b/logic/src/main/java/org/itsallcode/whiterabbit/logic/service/plugin/AppPlugin.java
@@ -1,6 +1,7 @@
 package org.itsallcode.whiterabbit.logic.service.plugin;
 
 import java.util.Collection;
+import java.util.Optional;
 
 import org.itsallcode.whiterabbit.api.features.Holidays;
 import org.itsallcode.whiterabbit.api.features.MonthDataStorage;
@@ -12,6 +13,8 @@ public interface AppPlugin
     String getId();
 
     Collection<AppPluginFeature> getFeatures();
+
+    <T extends PluginFeature> Optional<T> getFeature(Class<T> featureType);
 
     AppPluginOrigin getOrigin();
 

--- a/logic/src/main/java/org/itsallcode/whiterabbit/logic/service/plugin/AppPluginImpl.java
+++ b/logic/src/main/java/org/itsallcode/whiterabbit/logic/service/plugin/AppPluginImpl.java
@@ -14,24 +14,24 @@ import org.itsallcode.whiterabbit.api.PluginConfiguration;
 import org.itsallcode.whiterabbit.api.features.PluginFeature;
 import org.itsallcode.whiterabbit.logic.Config;
 
-class PluginWrapper implements AppPlugin
+class AppPluginImpl implements AppPlugin
 {
-    private static final Logger LOG = LogManager.getLogger(PluginWrapper.class);
+    private static final Logger LOG = LogManager.getLogger(AppPluginImpl.class);
 
     private final AppPluginOrigin origin;
     private final Plugin plugin;
     private final Config config;
 
-    private PluginWrapper(Config config, AppPluginOrigin origin, Plugin plugin)
+    private AppPluginImpl(Config config, AppPluginOrigin origin, Plugin plugin)
     {
         this.config = config;
         this.origin = origin;
         this.plugin = plugin;
     }
 
-    public static PluginWrapper create(Config config, AppPluginOrigin origin, Plugin plugin)
+    public static AppPluginImpl create(Config config, AppPluginOrigin origin, Plugin plugin)
     {
-        return new PluginWrapper(config, origin, plugin);
+        return new AppPluginImpl(config, origin, plugin);
     }
 
     void init()

--- a/logic/src/main/java/org/itsallcode/whiterabbit/logic/service/plugin/PluginManager.java
+++ b/logic/src/main/java/org/itsallcode/whiterabbit/logic/service/plugin/PluginManager.java
@@ -38,7 +38,7 @@ public class PluginManager
                 .collect(toList());
     }
 
-    public List<PluginWrapper> findPluginsSupporting(Class<? extends PluginFeature> featureType)
+    public List<AppPlugin> findPluginsSupporting(Class<? extends PluginFeature> featureType)
     {
         return pluginRegistry.getAllPlugins().stream()
                 .filter(plugin -> plugin.supports(featureType))
@@ -53,7 +53,7 @@ public class PluginManager
 
     public <T extends PluginFeature> Optional<T> getUniqueFeature(Class<T> featureType)
     {
-        final List<PluginWrapper> plugins = findPluginsSupporting(featureType);
+        final List<AppPlugin> plugins = findPluginsSupporting(featureType);
         if (plugins.isEmpty())
         {
             return Optional.empty();

--- a/logic/src/main/java/org/itsallcode/whiterabbit/logic/service/plugin/PluginManager.java
+++ b/logic/src/main/java/org/itsallcode/whiterabbit/logic/service/plugin/PluginManager.java
@@ -8,9 +8,7 @@ import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.itsallcode.whiterabbit.api.features.MonthDataStorage;
 import org.itsallcode.whiterabbit.api.features.PluginFeature;
-import org.itsallcode.whiterabbit.api.features.ProjectReportExporter;
 import org.itsallcode.whiterabbit.logic.Config;
 
 public class PluginManager
@@ -34,20 +32,16 @@ public class PluginManager
     public <T extends PluginFeature> List<T> getAllFeatures(Class<T> featureType)
     {
         return findPluginsSupporting(featureType).stream()
-                .map(pluginId -> getFeature(pluginId, featureType))
+                .map(plugin -> plugin.getFeature(featureType))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
                 .collect(toList());
     }
 
-    public List<String> getProjectReportExporterPlugins()
-    {
-        return findPluginsSupporting(ProjectReportExporter.class);
-    }
-
-    private List<String> findPluginsSupporting(Class<? extends PluginFeature> featureType)
+    public List<PluginWrapper> findPluginsSupporting(Class<? extends PluginFeature> featureType)
     {
         return pluginRegistry.getAllPlugins().stream()
                 .filter(plugin -> plugin.supports(featureType))
-                .map(PluginWrapper::getId)
                 .collect(toList());
     }
 
@@ -57,43 +51,19 @@ public class PluginManager
         return pluginRegistry.getAllPlugins();
     }
 
-    public ProjectReportExporter getProjectReportExporter(String id)
+    public <T extends PluginFeature> Optional<T> getUniqueFeature(Class<T> featureType)
     {
-        return getFeature(id, ProjectReportExporter.class);
-    }
-
-    public Optional<MonthDataStorage> getMonthDataStorage()
-    {
-        return getUniqueFeature(MonthDataStorage.class);
-    }
-
-    private Optional<MonthDataStorage> getUniqueFeature(Class<MonthDataStorage> featureType)
-    {
-        final List<String> pluginIds = findPluginsSupporting(featureType);
-        if (pluginIds.isEmpty())
+        final List<PluginWrapper> plugins = findPluginsSupporting(featureType);
+        if (plugins.isEmpty())
         {
             return Optional.empty();
         }
-        if (pluginIds.size() > 1)
+        if (plugins.size() > 1)
         {
             throw new IllegalStateException("Found multiple plugins supporting " + featureType.getName()
-                    + ": " + pluginIds + ". Please add only one storage plugin to the classpath.");
+                    + ": " + plugins + ". Please add only one storage plugin to the classpath.");
         }
-        return Optional.of(getFeature(pluginIds.get(0), featureType));
-    }
-
-    private <T extends PluginFeature> T getFeature(String id, final Class<T> featureType)
-    {
-        final PluginWrapper plugin = pluginRegistry.getPlugin(id);
-        if (plugin == null)
-        {
-            throw new IllegalStateException("Plugin '" + id + "' not found");
-        }
-        if (!plugin.supports(featureType))
-        {
-            throw new IllegalStateException("Plugin '" + id + "' does not support feature " + featureType.getName());
-        }
-        return plugin.getFeature(featureType);
+        return plugins.get(0).getFeature(featureType);
     }
 
     public void close()

--- a/logic/src/main/java/org/itsallcode/whiterabbit/logic/service/plugin/PluginWrapper.java
+++ b/logic/src/main/java/org/itsallcode/whiterabbit/logic/service/plugin/PluginWrapper.java
@@ -14,7 +14,7 @@ import org.itsallcode.whiterabbit.api.PluginConfiguration;
 import org.itsallcode.whiterabbit.api.features.PluginFeature;
 import org.itsallcode.whiterabbit.logic.Config;
 
-public class PluginWrapper implements AppPlugin
+class PluginWrapper implements AppPlugin
 {
     private static final Logger LOG = LogManager.getLogger(PluginWrapper.class);
 

--- a/logic/src/main/java/org/itsallcode/whiterabbit/logic/service/plugin/PluginWrapper.java
+++ b/logic/src/main/java/org/itsallcode/whiterabbit/logic/service/plugin/PluginWrapper.java
@@ -14,7 +14,7 @@ import org.itsallcode.whiterabbit.api.PluginConfiguration;
 import org.itsallcode.whiterabbit.api.features.PluginFeature;
 import org.itsallcode.whiterabbit.logic.Config;
 
-class PluginWrapper implements AppPlugin
+public class PluginWrapper implements AppPlugin
 {
     private static final Logger LOG = LogManager.getLogger(PluginWrapper.class);
 
@@ -72,7 +72,7 @@ class PluginWrapper implements AppPlugin
         }
     }
 
-    <T extends PluginFeature> T getFeature(Class<T> featureType)
+    public <T extends PluginFeature> Optional<T> getFeature(Class<T> featureType)
     {
         return plugin.getFeature(featureType);
     }

--- a/logic/src/test/java/org/itsallcode/whiterabbit/logic/service/plugin/PluginManagerTest.java
+++ b/logic/src/test/java/org/itsallcode/whiterabbit/logic/service/plugin/PluginManagerTest.java
@@ -29,9 +29,9 @@ class PluginManagerTest
     private PluginRegistry pluginRegistryMock;
 
     @Mock
-    private PluginWrapper plugin1;
+    private AppPluginImpl plugin1;
     @Mock
-    private PluginWrapper plugin2;
+    private AppPluginImpl plugin2;
 
     @Mock
     Holidays holidays1;
@@ -100,10 +100,10 @@ class PluginManagerTest
         assertThat(pluginManager.getAllFeatures(Holidays.class)).containsExactly(holidays1);
     }
 
-    private void simulatePlugins(PluginWrapper... plugins)
+    private void simulatePlugins(AppPluginImpl... plugins)
     {
         lenient().when(pluginRegistryMock.getAllPlugins()).thenReturn(asList(plugins));
-        for (final PluginWrapper plugin : plugins)
+        for (final AppPluginImpl plugin : plugins)
         {
             lenient().when(pluginRegistryMock.getPlugin(plugin.getId())).thenReturn(plugin);
         }
@@ -180,7 +180,7 @@ class PluginManagerTest
     @Test
     void getAllPlugins()
     {
-        final Collection<PluginWrapper> plugins = new ArrayList<>();
+        final Collection<AppPluginImpl> plugins = new ArrayList<>();
         when(pluginRegistryMock.getAllPlugins()).thenReturn(plugins);
         assertThat(pluginManager.getAllPlugins()).isSameAs(plugins);
     }

--- a/logic/src/test/java/org/itsallcode/whiterabbit/logic/service/plugin/PluginManagerTest.java
+++ b/logic/src/test/java/org/itsallcode/whiterabbit/logic/service/plugin/PluginManagerTest.java
@@ -113,10 +113,8 @@ class PluginManagerTest
     void getProjectReportExporter_noPluginAvailable_throwsException()
     {
         simulatePlugins();
+
         assertThat(pluginManager.getAllFeatures(ProjectReportExporter.class)).isEmpty();
-        // assertThatThrownBy(() -> pluginManager.get("unknown"))
-        // .isInstanceOf(IllegalStateException.class)
-        // .hasMessage("Plugin 'unknown' not found");
     }
 
     @Test
@@ -124,12 +122,8 @@ class PluginManagerTest
     {
         simulatePlugins(plugin1);
         when(plugin1.supports(ProjectReportExporter.class)).thenReturn(false);
+
         assertThat(pluginManager.getAllFeatures(ProjectReportExporter.class)).isEmpty();
-        // assertThatThrownBy(() ->
-        // pluginManager.getProjectReportExporter("plugin1"))
-        // .isInstanceOf(IllegalStateException.class)
-        // .hasMessage("Plugin 'plugin1' does not support feature " +
-        // ProjectReportExporter.class.getName());
     }
 
     @Test

--- a/logic/src/test/java/org/itsallcode/whiterabbit/logic/service/plugin/PluginManagerTest.java
+++ b/logic/src/test/java/org/itsallcode/whiterabbit/logic/service/plugin/PluginManagerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Optional;
 
 import org.itsallcode.whiterabbit.api.features.Holidays;
 import org.itsallcode.whiterabbit.api.features.MonthDataStorage;
@@ -58,7 +59,7 @@ class PluginManagerTest
     void getProjectReportExporterPlugins_noPluginAvailable()
     {
         simulatePlugins();
-        assertThat(pluginManager.getProjectReportExporterPlugins()).isEmpty();
+        assertThat(pluginManager.findPluginsSupporting(ProjectReportExporter.class)).isEmpty();
     }
 
     @Test
@@ -66,7 +67,7 @@ class PluginManagerTest
     {
         simulatePlugins(plugin1);
         when(plugin1.supports(ProjectReportExporter.class)).thenReturn(false);
-        assertThat(pluginManager.getProjectReportExporterPlugins()).isEmpty();
+        assertThat(pluginManager.findPluginsSupporting(ProjectReportExporter.class)).isEmpty();
     }
 
     @Test
@@ -74,18 +75,29 @@ class PluginManagerTest
     {
         simulatePlugins(plugin1);
         when(plugin1.supports(ProjectReportExporter.class)).thenReturn(true);
-        assertThat(pluginManager.getProjectReportExporterPlugins()).containsExactly("plugin1");
+        assertThat(pluginManager.findPluginsSupporting(ProjectReportExporter.class)).containsExactly(plugin1);
     }
 
     @Test
     void getAllFeatures()
     {
-        when(plugin1.getFeature(Holidays.class)).thenReturn(holidays1);
-        when(plugin2.getFeature(Holidays.class)).thenReturn(holidays2);
+        when(plugin1.getFeature(Holidays.class)).thenReturn(Optional.of(holidays1));
+        when(plugin2.getFeature(Holidays.class)).thenReturn(Optional.of(holidays2));
         when(plugin1.supports(Holidays.class)).thenReturn(true);
         when(plugin2.supports(Holidays.class)).thenReturn(true);
         simulatePlugins(plugin1, plugin2);
         assertThat(pluginManager.getAllFeatures(Holidays.class)).containsExactly(holidays1, holidays2);
+    }
+
+    @Test
+    void pluginReturnsEmptyOptional()
+    {
+        when(plugin1.getFeature(Holidays.class)).thenReturn(Optional.of(holidays1));
+        when(plugin2.getFeature(Holidays.class)).thenReturn(Optional.empty());
+        when(plugin1.supports(Holidays.class)).thenReturn(true);
+        when(plugin2.supports(Holidays.class)).thenReturn(true);
+        simulatePlugins(plugin1, plugin2);
+        assertThat(pluginManager.getAllFeatures(Holidays.class)).containsExactly(holidays1);
     }
 
     private void simulatePlugins(PluginWrapper... plugins)
@@ -101,9 +113,10 @@ class PluginManagerTest
     void getProjectReportExporter_noPluginAvailable_throwsException()
     {
         simulatePlugins();
-        assertThatThrownBy(() -> pluginManager.getProjectReportExporter("unknown"))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Plugin 'unknown' not found");
+        assertThat(pluginManager.getAllFeatures(ProjectReportExporter.class)).isEmpty();
+        // assertThatThrownBy(() -> pluginManager.get("unknown"))
+        // .isInstanceOf(IllegalStateException.class)
+        // .hasMessage("Plugin 'unknown' not found");
     }
 
     @Test
@@ -111,9 +124,12 @@ class PluginManagerTest
     {
         simulatePlugins(plugin1);
         when(plugin1.supports(ProjectReportExporter.class)).thenReturn(false);
-        assertThatThrownBy(() -> pluginManager.getProjectReportExporter("plugin1"))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Plugin 'plugin1' does not support feature " + ProjectReportExporter.class.getName());
+        assertThat(pluginManager.getAllFeatures(ProjectReportExporter.class)).isEmpty();
+        // assertThatThrownBy(() ->
+        // pluginManager.getProjectReportExporter("plugin1"))
+        // .isInstanceOf(IllegalStateException.class)
+        // .hasMessage("Plugin 'plugin1' does not support feature " +
+        // ProjectReportExporter.class.getName());
     }
 
     @Test
@@ -122,9 +138,9 @@ class PluginManagerTest
         simulatePlugins(plugin1);
         when(plugin1.supports(ProjectReportExporter.class)).thenReturn(true);
         final ProjectReportExporter featureMock = mock(ProjectReportExporter.class);
-        when(plugin1.getFeature(ProjectReportExporter.class)).thenReturn(featureMock);
+        when(plugin1.getFeature(ProjectReportExporter.class)).thenReturn(Optional.of(featureMock));
 
-        assertThat(pluginManager.getProjectReportExporter("plugin1")).isNotNull().isSameAs(featureMock);
+        assertThat(pluginManager.getAllFeatures(ProjectReportExporter.class)).hasSize(1).contains(featureMock);
     }
 
     @Test
@@ -133,9 +149,9 @@ class PluginManagerTest
         simulatePlugins(plugin1);
         when(plugin1.supports(MonthDataStorage.class)).thenReturn(true);
         final MonthDataStorage featureMock = mock(MonthDataStorage.class);
-        when(plugin1.getFeature(MonthDataStorage.class)).thenReturn(featureMock);
+        when(plugin1.getFeature(MonthDataStorage.class)).thenReturn(Optional.of(featureMock));
 
-        assertThat(pluginManager.getMonthDataStorage()).isPresent().containsSame(featureMock);
+        assertThat(pluginManager.getUniqueFeature(MonthDataStorage.class)).isPresent().containsSame(featureMock);
     }
 
     @Test
@@ -144,7 +160,7 @@ class PluginManagerTest
         simulatePlugins(plugin1);
         when(plugin1.supports(MonthDataStorage.class)).thenReturn(false);
 
-        assertThat(pluginManager.getMonthDataStorage()).isEmpty();
+        assertThat(pluginManager.getUniqueFeature(MonthDataStorage.class)).isEmpty();
     }
 
     @Test
@@ -154,7 +170,7 @@ class PluginManagerTest
         when(plugin1.supports(MonthDataStorage.class)).thenReturn(true);
         when(plugin2.supports(MonthDataStorage.class)).thenReturn(true);
 
-        assertThatThrownBy(() -> pluginManager.getMonthDataStorage())
+        assertThatThrownBy(() -> pluginManager.getUniqueFeature(MonthDataStorage.class))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage(
                         "Found multiple plugins supporting " + MonthDataStorage.class.getName()

--- a/logic/src/test/java/org/itsallcode/whiterabbit/logic/service/plugin/PluginRegistryTest.java
+++ b/logic/src/test/java/org/itsallcode/whiterabbit/logic/service/plugin/PluginRegistryTest.java
@@ -72,7 +72,7 @@ class PluginRegistryTest
     void getAllPlugins_returnsPlugins_WhenLoaded()
     {
         pluginRegistry.load();
-        final Collection<PluginWrapper> plugins = pluginRegistry.getAllPlugins();
+        final Collection<AppPluginImpl> plugins = pluginRegistry.getAllPlugins();
         assertThat(plugins).hasSize(EXPECTED_PLUGIN_COUNT);
     }
 
@@ -98,7 +98,7 @@ class PluginRegistryTest
     void getPlugin_returnsPluginWhenAvailable()
     {
         pluginRegistry.load();
-        final PluginWrapper plugin = pluginRegistry.getPlugin(TestingPlugin.PLUGIN_ID);
+        final AppPluginImpl plugin = pluginRegistry.getPlugin(TestingPlugin.PLUGIN_ID);
         assertThat(plugin.getId()).isEqualTo(TestingPlugin.PLUGIN_ID);
         assertThat(plugin.getOrigin().getDescription()).isEqualTo("included");
         assertThat(plugin.getFeatures()).isEmpty();
@@ -114,7 +114,7 @@ class PluginRegistryTest
     void getPlugin_featureNotAvailable()
     {
         pluginRegistry.load();
-        final PluginWrapper plugin = pluginRegistry.getPlugin(TestingPlugin.PLUGIN_ID);
+        final AppPluginImpl plugin = pluginRegistry.getPlugin(TestingPlugin.PLUGIN_ID);
         assertThat(plugin.getId()).isEqualTo(TestingPlugin.PLUGIN_ID);
         assertThat(plugin.getOrigin().getDescription()).isEqualTo("included");
         assertThat(plugin.getFeatures()).isEmpty();
@@ -125,7 +125,7 @@ class PluginRegistryTest
     void getPlugin_withFeature()
     {
         pluginRegistry.load();
-        final PluginWrapper plugin = pluginRegistry.getPlugin(TestingReportPlugin.PLUGIN_ID);
+        final AppPluginImpl plugin = pluginRegistry.getPlugin(TestingReportPlugin.PLUGIN_ID);
         assertThat(plugin.getId()).isEqualTo(TestingReportPlugin.PLUGIN_ID);
         assertThat(plugin.getFeatures()).hasSize(1).containsExactly(AppPluginFeature.PROJECT_REPORT);
     }

--- a/logic/src/test/java/org/itsallcode/whiterabbit/logic/service/plugin/PluginRegistryTest.java
+++ b/logic/src/test/java/org/itsallcode/whiterabbit/logic/service/plugin/PluginRegistryTest.java
@@ -10,7 +10,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.Optional;
 
+import org.itsallcode.whiterabbit.api.features.ProjectReportExporter;
 import org.itsallcode.whiterabbit.logic.Config;
 import org.itsallcode.whiterabbit.logic.service.plugin.AppPlugin.AppPluginFeature;
 import org.junit.jupiter.api.BeforeEach;
@@ -100,10 +102,23 @@ class PluginRegistryTest
         assertThat(plugin.getId()).isEqualTo(TestingPlugin.PLUGIN_ID);
         assertThat(plugin.getOrigin().getDescription()).isEqualTo("included");
         assertThat(plugin.getFeatures()).isEmpty();
-        final TestingPlugin pluginInstance = plugin.getFeature(TestingPlugin.class);
+        final Optional<TestingPlugin> optionalInstance = plugin.getFeature(TestingPlugin.class);
+        assertThat(optionalInstance).isPresent();
+        final TestingPlugin pluginInstance = optionalInstance.get();
         assertThat(pluginInstance).isInstanceOf(TestingPlugin.class);
         assertThat(pluginInstance.getId()).isEqualTo(TestingPlugin.PLUGIN_ID);
         assertThat(pluginInstance.isClosed()).isFalse();
+    }
+
+    @Test
+    void getPlugin_featureNotAvailable()
+    {
+        pluginRegistry.load();
+        final PluginWrapper plugin = pluginRegistry.getPlugin(TestingPlugin.PLUGIN_ID);
+        assertThat(plugin.getId()).isEqualTo(TestingPlugin.PLUGIN_ID);
+        assertThat(plugin.getOrigin().getDescription()).isEqualTo("included");
+        assertThat(plugin.getFeatures()).isEmpty();
+        assertThat(plugin.getFeature(ProjectReportExporter.class)).isEmpty();
     }
 
     @Test
@@ -120,7 +135,7 @@ class PluginRegistryTest
     {
         pluginRegistry.load();
         final TestingPlugin pluginInstance = pluginRegistry.getPlugin(TestingPlugin.PLUGIN_ID)
-                .getFeature(TestingPlugin.class);
+                .getFeature(TestingPlugin.class).get();
 
         when(configMock.getMandatoryValue(TestingPlugin.PLUGIN_ID + ".property")).thenReturn("propertyValue");
         assertThat(pluginInstance.getConfig().getMandatoryValue("property")).isEqualTo("propertyValue");
@@ -136,7 +151,8 @@ class PluginRegistryTest
     void close_closesPlugins()
     {
         pluginRegistry.load();
-        final TestingPlugin plugin = pluginRegistry.getPlugin(TestingPlugin.PLUGIN_ID).getFeature(TestingPlugin.class);
+        final TestingPlugin plugin = pluginRegistry.getPlugin(TestingPlugin.PLUGIN_ID).getFeature(TestingPlugin.class)
+                .get();
         assertThat(plugin.isClosed()).isFalse();
 
         pluginRegistry.close();

--- a/logic/src/test/java/org/itsallcode/whiterabbit/logic/service/plugin/TestingPlugin.java
+++ b/logic/src/test/java/org/itsallcode/whiterabbit/logic/service/plugin/TestingPlugin.java
@@ -1,5 +1,7 @@
 package org.itsallcode.whiterabbit.logic.service.plugin;
 
+import java.util.Optional;
+
 import org.itsallcode.whiterabbit.api.Plugin;
 import org.itsallcode.whiterabbit.api.PluginConfiguration;
 import org.itsallcode.whiterabbit.api.features.PluginFeature;
@@ -35,9 +37,16 @@ public class TestingPlugin implements Plugin, PluginFeature
     }
 
     @Override
-    public <T extends PluginFeature> T getFeature(Class<T> featureType)
+    public <T extends PluginFeature> Optional<T> getFeature(Class<T> featureType)
     {
-        return featureType.cast(this);
+        if (this.supports(featureType))
+        {
+            return Optional.of(featureType.cast(this));
+        }
+        else
+        {
+            return Optional.empty();
+        }
     }
 
     public PluginConfiguration getConfig()

--- a/logic/src/test/java/org/itsallcode/whiterabbit/logic/service/plugin/TestingReportPlugin.java
+++ b/logic/src/test/java/org/itsallcode/whiterabbit/logic/service/plugin/TestingReportPlugin.java
@@ -1,5 +1,7 @@
 package org.itsallcode.whiterabbit.logic.service.plugin;
 
+import java.util.Optional;
+
 import org.itsallcode.whiterabbit.api.Plugin;
 import org.itsallcode.whiterabbit.api.PluginConfiguration;
 import org.itsallcode.whiterabbit.api.features.PluginFeature;
@@ -38,9 +40,9 @@ public class TestingReportPlugin implements Plugin, ProjectReportExporter
     }
 
     @Override
-    public <T extends PluginFeature> T getFeature(Class<T> featureType)
+    public <T extends PluginFeature> Optional<T> getFeature(Class<T> featureType)
     {
-        return featureType.cast(this);
+        return Optional.of(featureType.cast(this));
     }
 
     public PluginConfiguration getConfig()

--- a/plugins/csv/.settings/org.sonarlint.eclipse.core.prefs
+++ b/plugins/csv/.settings/org.sonarlint.eclipse.core.prefs
@@ -3,4 +3,4 @@ eclipse.preferences.version=1
 idePrefixKey=
 projectKey=white-rabbit
 serverId=SonarCloud/itsallcode
-sqPrefixKey=plugins/demo
+sqPrefixKey=

--- a/plugins/csv/src/main/java/org/itsallcode/whiterabbit/plugin/csv/CSVConfig.java
+++ b/plugins/csv/src/main/java/org/itsallcode/whiterabbit/plugin/csv/CSVConfig.java
@@ -1,33 +1,37 @@
 package org.itsallcode.whiterabbit.plugin.csv;
 
-import org.itsallcode.whiterabbit.api.PluginConfiguration;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-public class CSVConfig {
+import org.itsallcode.whiterabbit.api.PluginConfiguration;
+
+class CSVConfig
+{
     private final boolean filterForWeekDays;
     private final Path outPath;
     private final String separator;
 
-    public boolean getFilterForWeekDays() {
+    boolean getFilterForWeekDays()
+    {
         return filterForWeekDays;
     }
 
-    public Path getOutPath() {
+    Path getOutPath()
+    {
         return outPath;
     }
 
-    public String getSeparator() {
+    String getSeparator()
+    {
         return separator;
     }
 
-    public CSVConfig(PluginConfiguration config) {
+    CSVConfig(PluginConfiguration config)
+    {
         final String defaultPath = System.getProperty("user.home");
         this.outPath = Paths.get(config.getOptionalValue("destination").orElse(defaultPath));
         this.separator = config.getOptionalValue("separator").orElse(",");
-        this.filterForWeekDays =
-                config.getOptionalValue("filter_for_weekdays")
-                        .orElse("false").equalsIgnoreCase("true");
+        this.filterForWeekDays = config.getOptionalValue("filter_for_weekdays")
+                .orElse("false").equalsIgnoreCase("true");
     }
 }

--- a/plugins/csv/src/main/java/org/itsallcode/whiterabbit/plugin/csv/CSVExporterPlugin.java
+++ b/plugins/csv/src/main/java/org/itsallcode/whiterabbit/plugin/csv/CSVExporterPlugin.java
@@ -1,12 +1,13 @@
 package org.itsallcode.whiterabbit.plugin.csv;
 
 import org.itsallcode.whiterabbit.api.AbstractPlugin;
+import org.itsallcode.whiterabbit.api.features.ProjectReportExporter;
 
-public class CSVExporterPlugin extends AbstractPlugin<CSVProjectReportExporter>
+public class CSVExporterPlugin extends AbstractPlugin<ProjectReportExporter>
 {
     public CSVExporterPlugin()
     {
-        super("csv", CSVProjectReportExporter.class);
+        super("csv", ProjectReportExporter.class);
     }
 
     @Override

--- a/plugins/csv/src/main/java/org/itsallcode/whiterabbit/plugin/csv/CSVProjectReportExporter.java
+++ b/plugins/csv/src/main/java/org/itsallcode/whiterabbit/plugin/csv/CSVProjectReportExporter.java
@@ -17,33 +17,38 @@ import org.itsallcode.whiterabbit.api.model.ProjectReport;
 import org.itsallcode.whiterabbit.api.model.ProjectReportActivity;
 import org.itsallcode.whiterabbit.api.model.ProjectReportDay;
 
-class CSVProjectReportExporter implements ProjectReportExporter {
+class CSVProjectReportExporter implements ProjectReportExporter
+{
     private final OutStreamProvider outStreamProvider;
     private final CSVConfig csvConfig;
 
-    CSVProjectReportExporter(CSVConfig csvConfig, OutStreamProvider outStreamProvider) {
+    CSVProjectReportExporter(CSVConfig csvConfig, OutStreamProvider outStreamProvider)
+    {
         this.csvConfig = csvConfig;
         this.outStreamProvider = outStreamProvider;
     }
 
     @Override
-    public void export(ProjectReport report, ProgressMonitor progressMonitor) {
+    public void export(ProjectReport report, ProgressMonitor progressMonitor)
+    {
         progressMonitor.setTaskName("Exporting...");
-        if (progressMonitor.isCanceled()) {
+        if (progressMonitor.isCanceled())
+        {
             return;
         }
         final String separator = csvConfig.getSeparator();
 
-        final List<ProjectReportDay> filteredDays =
-                report.getDays().stream()
-                        .filter(Objects::nonNull)
-                        .filter(day -> !csvConfig.getFilterForWeekDays() || day.getType() == DayType.WORK)
-                        .collect(Collectors.toList());
+        final List<ProjectReportDay> filteredDays = report.getDays().stream()
+                .filter(Objects::nonNull)
+                .filter(day -> !csvConfig.getFilterForWeekDays() || day.getType() == DayType.WORK)
+                .collect(Collectors.toList());
 
-        try (final PrintStream os = new PrintStream(outStreamProvider.getStream(report.getMonth().toString()))) {
+        try (final PrintStream os = new PrintStream(outStreamProvider.getStream(report.getMonth().toString())))
+        {
             os.println(MessageFormat.format("Date{0}Project{0}TimePerProject{0}TimePerDay{0}Comment", separator));
 
-            for (final ProjectReportDay day : filteredDays) {
+            for (final ProjectReportDay day : filteredDays)
+            {
                 final String dayComment = formatEmptyString(day.getComment());
                 final Duration dayWorkingTime = day.getProjects() == null ? Duration.ZERO : getDayWorkingTime(day);
                 final String dayDurationStr = formatDuration(dayWorkingTime);
@@ -51,8 +56,10 @@ class CSVProjectReportExporter implements ProjectReportExporter {
                 os.println(MessageFormat.format("{0}{1}{1}{1}{2}{1}{3}",
                         day.getDate(), separator, dayDurationStr, dayComment));
 
-                if (day.getProjects() != null) {
-                    for (final ProjectReportActivity project : day.getProjects()) {
+                if (day.getProjects() != null)
+                {
+                    for (final ProjectReportActivity project : day.getProjects())
+                    {
                         final String projectWorkingTime = formatDuration(project.getWorkingTime());
                         final String projectLabel = formatEmptyString(project.getProject().getLabel());
                         final String activityComment = formatEmptyString(project.getComment());
@@ -61,22 +68,27 @@ class CSVProjectReportExporter implements ProjectReportExporter {
                     }
                 }
             }
-        } catch (IOException ex) {
+        }
+        catch (final IOException ex)
+        {
             throw new UncheckedIOException("Error exporting report to CSV:" + ex, ex);
         }
     }
 
-    private Duration getDayWorkingTime(ProjectReportDay day) {
+    private Duration getDayWorkingTime(ProjectReportDay day)
+    {
         return day.getProjects().stream().reduce(Duration.ZERO,
-                (subtotal, element) -> element == null ?
-                        subtotal : element.getWorkingTime().plus(subtotal), Duration::plus);
+                (subtotal, element) -> element == null ? subtotal : element.getWorkingTime().plus(subtotal),
+                Duration::plus);
     }
 
-    private String formatEmptyString(String value) {
+    private String formatEmptyString(String value)
+    {
         return value == null ? "" : value;
     }
 
-    private String formatDuration(Duration duration) {
+    private String formatDuration(Duration duration)
+    {
         final long minutes = TimeUnit.SECONDS.toMinutes(duration.getSeconds());
         final long absMinutes = Math.abs(minutes);
         final String positive = String.format("%02d:%02d", absMinutes / 60, absMinutes % 60);

--- a/plugins/csv/src/main/java/org/itsallcode/whiterabbit/plugin/csv/DirectoryStreamProvider.java
+++ b/plugins/csv/src/main/java/org/itsallcode/whiterabbit/plugin/csv/DirectoryStreamProvider.java
@@ -5,17 +5,25 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-public class DirectoryStreamProvider implements OutStreamProvider {
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
+class DirectoryStreamProvider implements OutStreamProvider
+{
+    private static final Logger LOG = LogManager.getLogger(DirectoryStreamProvider.class);
     private final Path outPath;
 
-    DirectoryStreamProvider(Path outPath) {
-        this.outPath= outPath;
+    DirectoryStreamProvider(Path outPath)
+    {
+        this.outPath = outPath;
     }
 
     @Override
-    public OutputStream getStream(String name) throws IOException {
+    public OutputStream getStream(String name) throws IOException
+    {
         final String outFile = String.format("%s_working_time.csv", name);
-        return Files.newOutputStream(outPath.resolve(outFile));
+        final Path path = outPath.resolve(outFile);
+        LOG.info("Writing output to {}", path);
+        return Files.newOutputStream(path);
     }
 }

--- a/plugins/csv/src/main/java/org/itsallcode/whiterabbit/plugin/csv/OutStreamProvider.java
+++ b/plugins/csv/src/main/java/org/itsallcode/whiterabbit/plugin/csv/OutStreamProvider.java
@@ -3,6 +3,7 @@ package org.itsallcode.whiterabbit.plugin.csv;
 import java.io.IOException;
 import java.io.OutputStream;
 
-public interface OutStreamProvider {
+interface OutStreamProvider
+{
     OutputStream getStream(String name) throws IOException;
 }

--- a/plugins/csv/src/test/java/org/itsallcode/whiterabbit/plugin/csv/CSVExporterPluginTest.java
+++ b/plugins/csv/src/test/java/org/itsallcode/whiterabbit/plugin/csv/CSVExporterPluginTest.java
@@ -1,0 +1,46 @@
+package org.itsallcode.whiterabbit.plugin.csv;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.itsallcode.whiterabbit.api.PluginConfiguration;
+import org.itsallcode.whiterabbit.api.features.Holidays;
+import org.itsallcode.whiterabbit.api.features.ProjectReportExporter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CSVExporterPluginTest
+{
+    @Mock
+    private PluginConfiguration configMock;
+
+    private CSVExporterPlugin plugin;
+
+    @BeforeEach
+    void setUp()
+    {
+        plugin = new CSVExporterPlugin();
+    }
+
+    @Test
+    void pluginSupportsProjectReportExporterFeature()
+    {
+        assertThat(plugin.supports(ProjectReportExporter.class)).isTrue();
+    }
+
+    @Test
+    void pluginDoesNotSupportHolidaysFeature()
+    {
+        assertThat(plugin.supports(Holidays.class)).isFalse();
+    }
+
+    @Test
+    void getFeature()
+    {
+        plugin.init(configMock);
+        assertThat(plugin.getFeature(ProjectReportExporter.class)).isNotNull();
+    }
+}

--- a/plugins/demo/src/main/java/org/itsallcode/whiterabbit/plugin/demo/DemoPlugin.java
+++ b/plugins/demo/src/main/java/org/itsallcode/whiterabbit/plugin/demo/DemoPlugin.java
@@ -1,5 +1,7 @@
 package org.itsallcode.whiterabbit.plugin.demo;
 
+import java.util.Optional;
+
 import org.itsallcode.whiterabbit.api.Plugin;
 import org.itsallcode.whiterabbit.api.PluginConfiguration;
 import org.itsallcode.whiterabbit.api.features.PluginFeature;
@@ -31,12 +33,12 @@ public class DemoPlugin implements Plugin
     }
 
     @Override
-    public <T extends PluginFeature> T getFeature(Class<T> featureType)
+    public <T extends PluginFeature> Optional<T> getFeature(Class<T> featureType)
     {
         if (featureType.isAssignableFrom(DemoProjectReportExporter.class))
         {
-            return featureType.cast(new DemoProjectReportExporter());
+            return Optional.of(featureType.cast(new DemoProjectReportExporter()));
         }
-        throw new IllegalArgumentException("Feature " + featureType.getName() + " not supported by plugin " + getId());
+        return Optional.empty();
     }
 }

--- a/plugins/holiday-calculator/.settings/org.sonarlint.eclipse.core.prefs
+++ b/plugins/holiday-calculator/.settings/org.sonarlint.eclipse.core.prefs
@@ -3,4 +3,4 @@ eclipse.preferences.version=1
 idePrefixKey=
 projectKey=white-rabbit
 serverId=SonarCloud/itsallcode
-sqPrefixKey=plugins/demo
+sqPrefixKey=

--- a/plugins/holiday-calculator/src/main/java/org/itsallcode/whiterabbit/plugin/holidaycalculator/HolidayCalculatorPlugin.java
+++ b/plugins/holiday-calculator/src/main/java/org/itsallcode/whiterabbit/plugin/holidaycalculator/HolidayCalculatorPlugin.java
@@ -1,12 +1,13 @@
 package org.itsallcode.whiterabbit.plugin.holidaycalculator;
 
 import org.itsallcode.whiterabbit.api.AbstractPlugin;
+import org.itsallcode.whiterabbit.api.features.Holidays;
 
-public class HolidayCalculatorPlugin extends AbstractPlugin<CalculatedHolidays>
+public class HolidayCalculatorPlugin extends AbstractPlugin<Holidays>
 {
     public HolidayCalculatorPlugin()
     {
-        super("holidaycalculator", CalculatedHolidays.class);
+        super("holidaycalculator", Holidays.class);
     }
 
     @Override

--- a/plugins/holiday-calculator/src/test/java/org/itsallcode/whiterabbit/plugin/holidaycalculator/HolidayCalculatorPluginTest.java
+++ b/plugins/holiday-calculator/src/test/java/org/itsallcode/whiterabbit/plugin/holidaycalculator/HolidayCalculatorPluginTest.java
@@ -1,0 +1,54 @@
+package org.itsallcode.whiterabbit.plugin.holidaycalculator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Path;
+
+import org.itsallcode.whiterabbit.api.PluginConfiguration;
+import org.itsallcode.whiterabbit.api.features.Holidays;
+import org.itsallcode.whiterabbit.api.features.ProjectReportExporter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class HolidayCalculatorPluginTest
+{
+    @Mock
+    private PluginConfiguration configMock;
+
+    @TempDir
+    Path dataDir;
+
+    private HolidayCalculatorPlugin plugin;
+
+    @BeforeEach
+    void setUp()
+    {
+        plugin = new HolidayCalculatorPlugin();
+    }
+
+    @Test
+    void pluginSupportsHolidaysFeature()
+    {
+        assertThat(plugin.supports(Holidays.class)).isTrue();
+    }
+
+    @Test
+    void pluginDoesNotSupportProjectReportExporterFeature()
+    {
+        assertThat(plugin.supports(ProjectReportExporter.class)).isFalse();
+    }
+
+    @Test
+    void getFeature()
+    {
+        when(configMock.getDataDir()).thenReturn(dataDir);
+        plugin.init(configMock);
+        assertThat(plugin.getFeature(Holidays.class)).isNotNull();
+    }
+}

--- a/plugins/pmsmart/src/main/java/org/itsallcode/whiterabbit/plugin/pmsmart/PMSmartExportPlugin.java
+++ b/plugins/pmsmart/src/main/java/org/itsallcode/whiterabbit/plugin/pmsmart/PMSmartExportPlugin.java
@@ -1,5 +1,7 @@
 package org.itsallcode.whiterabbit.plugin.pmsmart;
 
+import java.util.Optional;
+
 import org.itsallcode.whiterabbit.api.Plugin;
 import org.itsallcode.whiterabbit.api.PluginConfiguration;
 import org.itsallcode.whiterabbit.api.features.PluginFeature;
@@ -22,13 +24,13 @@ public class PMSmartExportPlugin implements Plugin
     }
 
     @Override
-    public <T extends PluginFeature> T getFeature(Class<T> featureType)
+    public <T extends PluginFeature> Optional<T> getFeature(Class<T> featureType)
     {
         if (featureType.isAssignableFrom(PMSmartExporter.class))
         {
-            return featureType.cast(new PMSmartExporter(config, new WebDriverFactory()));
+            return Optional.of(featureType.cast(new PMSmartExporter(config, new WebDriverFactory())));
         }
-        throw new IllegalArgumentException("Feature " + featureType.getName() + " not supported by plugin " + getId());
+        return Optional.empty();
     }
 
     @Override


### PR DESCRIPTION
This simplifies the Plugin interface by returning an empty `Optional` instead of `null` or throwing an exception.

This requires adapting third party plugins and rebuilding plugins installed to `~/.whiterabbit/plugins/`.