### PR TITLE
Use native system tray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,13 @@ See [Release](https://github.com/itsallcode/white-rabbit/releases/tag/v1.7.0) / 
 
 ### Added
 
-* [#158](https://github.com/itsallcode/white-rabbit/issues/158): PMSmart plugin: Support optional configuration  `pmsmart.transfer.comments` to skip transfer of comments.
-* [#150](https://github.com/itsallcode/white-rabbit/issues/150): PMSmart plugin: Support optional configuration  `pmsmart.clear_other_projects` to clear durations for all other projects.
+* [#158](https://github.com/itsallcode/white-rabbit/issues/158): PMSmart plugin: Support optional configuration `pmsmart.transfer.comments` to skip transfer of comments.
+* [#150](https://github.com/itsallcode/white-rabbit/issues/150): PMSmart plugin: Support optional configuration `pmsmart.clear_other_projects` to clear durations for all other projects.
 * [#131](https://github.com/itsallcode/white-rabbit/issues/131) / [PR #165](https://github.com/itsallcode/white-rabbit/pull/165): Allow deleting activities by typing the Delete key.
 * [#164](https://github.com/itsallcode/white-rabbit/pull/164): Improve label of empty activities table.
 * [#115](https://github.com/itsallcode/white-rabbit/issues/115): Added holiday-calculator plugin: calculate holidays, see [README.md](README.md#holidays_calculator) for details.
 * [#175](https://github.com/itsallcode/white-rabbit/pull/175): CSV Exporter Plugin: Initial version.
+* [#201](https://github.com/itsallcode/white-rabbit/pull/201): Use [SystemTray](https://github.com/dorkbox/SystemTray) instead of AWT tray by default. You can add optional configuration `system.tray = awt` to keep using AWT.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Restart WhiteRabbit after changing the configuration file.
 * `locale`: format of date and time values as an [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag), e.g. `de`, `de-DE` or `en-GB`. Default: system locale.
   * Note: enter a locale with country code (e.g. `de-DE`) to get correct formatting of date and time, e.g. the calendar week.
 * `current_working_time_per_day`: custom working time per day differing from the default of 8 hours. Format: see [Duration.parse()](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence)), e.g. `PT5H` for 5 hours or `PT5H30M` for 5 hours and 30 minutes. This setting will only affect the future.
+* `system.tray = awt`: use classic AWT system tray instead of [SystemTray](https://github.com/dorkbox/SystemTray).
+
 
 #### <a name="project_config"></a>Project configuration
 

--- a/jfxui/build.gradle
+++ b/jfxui/build.gradle
@@ -15,6 +15,8 @@ dependencies {
         implementation "org.openjfx:javafx-controls:$javaFxVersion:$platform"
     }
 
+    implementation "com.dorkbox:SystemTray:4.1"
+
     implementation "org.apache.logging.log4j:log4j-api:$log4jVersion"
     implementation "org.eclipse.jdt:org.eclipse.jdt.annotation:2.2.600"
     implementation "javax.json.bind:javax.json.bind-api:${jsonBindApiVersion}"

--- a/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/tray/AwtTrayIcon.java
+++ b/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/tray/AwtTrayIcon.java
@@ -24,6 +24,11 @@ class AwtTrayIcon implements Tray
         this.trayIcon = trayIcon;
     }
 
+    static boolean isAwtTraySupported()
+    {
+        return SystemTray.isSupported();
+    }
+
     static Tray createAwtTray(TrayCallback callback)
     {
         return SwingUtil.runOnSwingThread(() -> createAwtTrayInternal(callback));

--- a/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/tray/AwtTrayIcon.java
+++ b/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/tray/AwtTrayIcon.java
@@ -1,20 +1,12 @@
 package org.itsallcode.whiterabbit.jfxui.tray;
 
-import java.awt.Dimension;
 import java.awt.Image;
 import java.awt.MenuItem;
 import java.awt.MenuShortcut;
 import java.awt.PopupMenu;
 import java.awt.SystemTray;
 import java.awt.TrayIcon;
-import java.awt.TrayIcon.MessageType;
 import java.awt.event.KeyEvent;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.net.URL;
-
-import javax.imageio.ImageIO;
-import javax.swing.SwingUtilities;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -35,10 +27,17 @@ class AwtTrayIcon implements Tray
 
     static @NonNull Tray createAwtTray(TrayCallback callback)
     {
+        return SwingUtil.runOnSwingThread(() -> {
+            return createAwtTrayInternal(callback);
+        });
+    }
+
+    private static @NonNull Tray createAwtTrayInternal(TrayCallback callback)
+    {
         try
         {
             final SystemTray tray = SystemTray.getSystemTray();
-            final Image scaledIcon = loadImage("/icon.png", tray.getTrayIconSize());
+            final Image scaledIcon = TrayUtil.loadImage(tray.getTrayIconSize());
             final TrayIcon trayIcon = new TrayIcon(scaledIcon, "White Rabbit Time Recording",
                     createPopupMenu(callback));
             LOG.info("Adding tray icon {}", trayIcon);
@@ -49,21 +48,6 @@ class AwtTrayIcon implements Tray
         catch (final Exception e)
         {
             throw new IllegalStateException("Error creating system tray: " + e.getMessage(), e);
-        }
-    }
-
-    private static Image loadImage(final String resourceName, Dimension size)
-    {
-        final URL imageUrl = AwtTrayIcon.class.getResource(resourceName);
-        try
-        {
-            final Image image = ImageIO.read(imageUrl);
-            LOG.debug("Scaling icon {} to {}", imageUrl, size);
-            return image.getScaledInstance(size.width, size.height, Image.SCALE_SMOOTH);
-        }
-        catch (final IOException e)
-        {
-            throw new UncheckedIOException("Error loading image " + resourceName, e);
         }
     }
 
@@ -88,12 +72,6 @@ class AwtTrayIcon implements Tray
     public void setTooltip(String tooltip)
     {
         trayIcon.setToolTip(tooltip);
-    }
-
-    @Override
-    public void displayMessage(String caption, String text, MessageType messageType)
-    {
-        SwingUtilities.invokeLater(() -> trayIcon.displayMessage(caption, text, messageType));
     }
 
     @Override

--- a/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/tray/AwtTrayIcon.java
+++ b/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/tray/AwtTrayIcon.java
@@ -10,7 +10,6 @@ import java.awt.event.KeyEvent;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.eclipse.jdt.annotation.NonNull;
 
 class AwtTrayIcon implements Tray
 {
@@ -25,14 +24,12 @@ class AwtTrayIcon implements Tray
         this.trayIcon = trayIcon;
     }
 
-    static @NonNull Tray createAwtTray(TrayCallback callback)
+    static Tray createAwtTray(TrayCallback callback)
     {
-        return SwingUtil.runOnSwingThread(() -> {
-            return createAwtTrayInternal(callback);
-        });
+        return SwingUtil.runOnSwingThread(() -> createAwtTrayInternal(callback));
     }
 
-    private static @NonNull Tray createAwtTrayInternal(TrayCallback callback)
+    private static Tray createAwtTrayInternal(TrayCallback callback)
     {
         try
         {

--- a/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/tray/DummyTrayIcon.java
+++ b/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/tray/DummyTrayIcon.java
@@ -1,20 +1,7 @@
 package org.itsallcode.whiterabbit.jfxui.tray;
 
-import java.awt.TrayIcon.MessageType;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 class DummyTrayIcon implements Tray
 {
-    private static final Logger LOG = LogManager.getLogger(DummyTrayIcon.class);
-
-    @Override
-    public void displayMessage(String caption, String text, MessageType messageType)
-    {
-        LOG.info("Display message with caption {} and text {} of type {}", caption, text, messageType);
-    }
-
     @Override
     public void removeTrayIcon()
     {

--- a/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/tray/NativeSystemTray.java
+++ b/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/tray/NativeSystemTray.java
@@ -1,0 +1,93 @@
+package org.itsallcode.whiterabbit.jfxui.tray;
+
+import java.awt.Dimension;
+import java.awt.Image;
+import java.awt.event.KeyEvent;
+
+import javax.swing.JMenuItem;
+import javax.swing.JSeparator;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import dorkbox.systemTray.Menu;
+import dorkbox.systemTray.SystemTray;
+
+public class NativeSystemTray implements Tray
+{
+    private static final Logger LOG = LogManager.getLogger(NativeSystemTray.class);
+
+    private final SystemTray tray;
+
+    private NativeSystemTray(SystemTray systemTray)
+    {
+        this.tray = systemTray;
+    }
+
+    static boolean isNativeSystemTraySupported()
+    {
+        return getNativeSystemTray() != null;
+    }
+
+    private static SystemTray getNativeSystemTray()
+    {
+        SystemTray.DEBUG = LOG.isTraceEnabled();
+        return SystemTray.get();
+    }
+
+    static NativeSystemTray create(TrayCallback callback)
+    {
+        final SystemTray systemTray = getNativeSystemTray();
+        if (systemTray == null)
+        {
+            throw new IllegalStateException("Unable to load SystemTray");
+        }
+        systemTray.installShutdownHook();
+        setIcon(systemTray);
+        populateMenuMenu(systemTray.getMenu(), callback);
+        systemTray.getMenu().setCallback(event -> callback.showMainWindow());
+        return new NativeSystemTray(systemTray);
+    }
+
+    private static void setIcon(final SystemTray systemTray)
+    {
+        final int trayImageSize = systemTray.getTrayImageSize();
+        final Dimension size = new Dimension(trayImageSize, trayImageSize);
+        final Image image = TrayUtil.loadImage(size);
+        systemTray.setImage(image);
+    }
+
+    private static void populateMenuMenu(Menu menu, TrayCallback callback)
+    {
+        menu.add(menuItem("Show", KeyEvent.VK_S, callback::showMainWindow));
+        menu.add(menuItem("Interruption", KeyEvent.VK_I, callback::startInterruption));
+        menu.add(new JSeparator());
+        menu.add(menuItem("Exit", KeyEvent.VK_E, callback::exit));
+    }
+
+    private static JMenuItem menuItem(String label, int shortcutKey, Runnable action)
+    {
+        final JMenuItem item = new JMenuItem(label);
+        item.setMnemonic(shortcutKey);
+        item.addActionListener(event -> action.run());
+        return item;
+    }
+
+    @Override
+    public void removeTrayIcon()
+    {
+        tray.shutdown();
+    }
+
+    @Override
+    public void setTooltip(String tooltip)
+    {
+        tray.setTooltip(tooltip);
+    }
+
+    @Override
+    public boolean isSupported()
+    {
+        return true;
+    }
+}

--- a/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/tray/SystemTrayService.java
+++ b/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/tray/SystemTrayService.java
@@ -1,0 +1,55 @@
+package org.itsallcode.whiterabbit.jfxui.tray;
+
+import java.awt.SystemTray;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.itsallcode.whiterabbit.logic.Config;
+
+public class SystemTrayService
+{
+    private static final Logger LOG = LogManager.getLogger(SystemTrayService.class);
+
+    private final Config config;
+
+    public SystemTrayService(Config config)
+    {
+        this.config = config;
+    }
+
+    public Tray createTray(TrayCallback callback)
+    {
+        if (getTrayType() == TrayType.AWT && SystemTray.isSupported())
+        {
+            LOG.debug("User selected AWT tray");
+            return AwtTrayIcon.createAwtTray(callback);
+        }
+
+        if (NativeSystemTray.isNativeSystemTraySupported())
+        {
+            LOG.debug("Using native system tray");
+            return NativeSystemTray.create(callback);
+        }
+
+        if (SystemTray.isSupported())
+        {
+            LOG.debug("Using AWT tray");
+            return AwtTrayIcon.createAwtTray(callback);
+        }
+
+        LOG.debug("No tray supported");
+        return new DummyTrayIcon();
+    }
+
+    private TrayType getTrayType()
+    {
+        return config.getOptionalValue("system.tray")
+                .map(value -> value.equalsIgnoreCase("awt") ? TrayType.AWT : TrayType.NATIVE_SYSTEM)
+                .orElse(TrayType.NATIVE_SYSTEM);
+    }
+
+    private enum TrayType
+    {
+        NATIVE_SYSTEM, AWT;
+    }
+}

--- a/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/tray/SystemTrayService.java
+++ b/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/tray/SystemTrayService.java
@@ -31,7 +31,7 @@ public class SystemTrayService
             return NativeSystemTray.create(callback);
         }
 
-        if (SystemTray.isSupported())
+        if (AwtTrayIcon.isAwtTraySupported())
         {
             LOG.debug("Using AWT tray");
             return AwtTrayIcon.createAwtTray(callback);

--- a/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/tray/Tray.java
+++ b/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/tray/Tray.java
@@ -1,24 +1,7 @@
 package org.itsallcode.whiterabbit.jfxui.tray;
 
-import java.awt.SystemTray;
-import java.awt.TrayIcon.MessageType;
-
 public interface Tray
 {
-    static Tray create(TrayCallback callback)
-    {
-        return SwingUtil.runOnSwingThread(() -> {
-            if (!SystemTray.isSupported())
-            {
-                return new DummyTrayIcon();
-            }
-
-            return AwtTrayIcon.createAwtTray(callback);
-        });
-    }
-
-    void displayMessage(String caption, String text, MessageType messageType);
-
     void removeTrayIcon();
 
     boolean isSupported();

--- a/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/tray/TrayUtil.java
+++ b/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/tray/TrayUtil.java
@@ -15,6 +15,11 @@ public class TrayUtil
 {
     private static final Logger LOG = LogManager.getLogger(TrayUtil.class);
 
+    private TrayUtil()
+    {
+        // not instantiable
+    }
+
     static Image loadImage(Dimension size)
     {
         return loadImage("/icon.png", size);

--- a/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/tray/TrayUtil.java
+++ b/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/tray/TrayUtil.java
@@ -1,0 +1,37 @@
+package org.itsallcode.whiterabbit.jfxui.tray;
+
+import java.awt.Dimension;
+import java.awt.Image;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URL;
+
+import javax.imageio.ImageIO;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class TrayUtil
+{
+    private static final Logger LOG = LogManager.getLogger(TrayUtil.class);
+
+    static Image loadImage(Dimension size)
+    {
+        return loadImage("/icon.png", size);
+    }
+
+    private static Image loadImage(final String resourceName, Dimension size)
+    {
+        final URL imageUrl = AwtTrayIcon.class.getResource(resourceName);
+        try
+        {
+            final Image image = ImageIO.read(imageUrl);
+            LOG.debug("Scaling icon {} to {}", imageUrl, size);
+            return image.getScaledInstance(size.width, size.height, Image.SCALE_SMOOTH);
+        }
+        catch (final IOException e)
+        {
+            throw new UncheckedIOException("Error loading image " + resourceName, e);
+        }
+    }
+}

--- a/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/ui/AppUi.java
+++ b/jfxui/src/main/java/org/itsallcode/whiterabbit/jfxui/ui/AppUi.java
@@ -15,6 +15,7 @@ import org.itsallcode.whiterabbit.jfxui.table.activities.ActivitiesTable;
 import org.itsallcode.whiterabbit.jfxui.table.activities.ActivityPropertyAdapter;
 import org.itsallcode.whiterabbit.jfxui.table.days.DayRecordPropertyAdapter;
 import org.itsallcode.whiterabbit.jfxui.table.days.DayRecordTable;
+import org.itsallcode.whiterabbit.jfxui.tray.SystemTrayService;
 import org.itsallcode.whiterabbit.jfxui.tray.Tray;
 import org.itsallcode.whiterabbit.jfxui.tray.TrayCallback;
 import org.itsallcode.whiterabbit.logic.model.DayRecord;
@@ -158,7 +159,7 @@ public class AppUi
 
         private void createTrayIcon()
         {
-            tray = Tray.create(new TrayCallback()
+            tray = new SystemTrayService(appService.config()).createTray(new TrayCallback()
             {
                 @Override
                 public void showMainWindow()
@@ -178,6 +179,8 @@ public class AppUi
                     actions.exitApp();
                 }
             });
+
+            tray.setTooltip("White Rabbit Time Recording");
 
             if (!tray.isSupported())
             {

--- a/jfxui/src/main/resources/log4j2.xml
+++ b/jfxui/src/main/resources/log4j2.xml
@@ -29,6 +29,9 @@
         <Logger level="INFO" name="org.asynchttpclient.netty" />
         <Logger level="INFO" name="io.netty" />
         <Logger level="INFO" name="org.openqa.selenium" />
+        <Logger level="INFO" name="com.sun.jna.Native" />
+        <Logger level="INFO" name="com.sun.jna.NativeLibrary" />
+        <Logger level="INFO" name="dorkbox.systemTray.SystemTray" />
         <Logger level="DEBUG" name="org.itsallcode" />
     </Loggers>
 </Configuration>

--- a/jfxui/src/test/java/org/itsallcode/whiterabbit/jfxui/tray/AwtTrayIconTest.java
+++ b/jfxui/src/test/java/org/itsallcode/whiterabbit/jfxui/tray/AwtTrayIconTest.java
@@ -1,0 +1,33 @@
+package org.itsallcode.whiterabbit.jfxui.tray;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AwtTrayIconTest
+{
+    @Mock
+    TrayCallback callbackMock;
+
+    @Test
+    void test()
+    {
+        assumeTrue(AwtTrayIcon.isAwtTraySupported());
+
+        final Tray tray = AwtTrayIcon.createAwtTray(callbackMock);
+        try
+        {
+            assertThat(tray.isSupported()).isTrue();
+            tray.setTooltip("tooltip");
+        }
+        finally
+        {
+            tray.removeTrayIcon();
+        }
+    }
+}

--- a/jfxui/src/test/java/org/itsallcode/whiterabbit/jfxui/tray/NativeSystemTrayTest.java
+++ b/jfxui/src/test/java/org/itsallcode/whiterabbit/jfxui/tray/NativeSystemTrayTest.java
@@ -1,0 +1,33 @@
+package org.itsallcode.whiterabbit.jfxui.tray;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NativeSystemTrayTest
+{
+    @Mock
+    TrayCallback callbackMock;
+
+    @Test
+    void test()
+    {
+        assumeTrue(NativeSystemTray.isNativeSystemTraySupported());
+
+        final Tray tray = NativeSystemTray.create(callbackMock);
+        try
+        {
+            assertThat(tray.isSupported()).isTrue();
+            tray.setTooltip("tooltip");
+        }
+        finally
+        {
+            tray.removeTrayIcon();
+        }
+    }
+}

--- a/jfxui/src/test/java/org/itsallcode/whiterabbit/jfxui/tray/TrayUtilTest.java
+++ b/jfxui/src/test/java/org/itsallcode/whiterabbit/jfxui/tray/TrayUtilTest.java
@@ -1,0 +1,20 @@
+package org.itsallcode.whiterabbit.jfxui.tray;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.awt.Dimension;
+import java.awt.Image;
+
+import org.junit.jupiter.api.Test;
+
+class TrayUtilTest
+{
+    @Test
+    void test()
+    {
+        final Image image = TrayUtil.loadImage(new Dimension(32, 32));
+        assertThat(image).isNotNull();
+        assertThat(image.getWidth(null)).isEqualTo(32);
+        assertThat(image.getHeight(null)).isEqualTo(32);
+    }
+}

--- a/logic/src/main/java/org/itsallcode/whiterabbit/logic/service/AppService.java
+++ b/logic/src/main/java/org/itsallcode/whiterabbit/logic/service/AppService.java
@@ -45,6 +45,7 @@ public class AppService implements Closeable
 {
     private static final Logger LOG = LogManager.getLogger(AppService.class);
 
+    private final Config config;
     private final WorkingTimeService workingTimeService;
     private final Storage storage;
     private final ClockService clock;
@@ -57,21 +58,19 @@ public class AppService implements Closeable
     private final ActivityService activityService;
     private final ProjectService projectService;
     private final AppPropertiesService appPropertiesService;
-
+    private final AutocompleteService autocompleteService;
+    private final PluginManager pluginManager;
     private RegistrationResult singleInstanceRegistration;
 
-    private final AutocompleteService autocompleteService;
-
-    private final PluginManager pluginManager;
-
     @SuppressWarnings("java:S107") // Large number of parameters is ok here.
-    AppService(WorkingTimeService workingTimeService, Storage storage, FormatterService formatterService,
+    AppService(Config config, WorkingTimeService workingTimeService, Storage storage, FormatterService formatterService,
             ClockService clock, SchedulingService schedulingService, SingleInstanceService singleInstanceService,
             DelegatingAppServiceCallback appServiceCallback, ActivityService activityService,
             ProjectService projectService, AutocompleteService autocompleteService,
             AppPropertiesService appPropertiesService, VacationReportGenerator vacationReportGenerator,
             ProjectReportGenerator projectReportGenerator, PluginManager pluginManager)
     {
+        this.config = config;
         this.workingTimeService = workingTimeService;
         this.storage = storage;
         this.formatterService = formatterService;
@@ -114,7 +113,7 @@ public class AppService implements Closeable
         final ProjectReportGenerator projectReportGenerator = new ProjectReportGenerator(storage);
         final ActivityService activityService = new ActivityService(storage, autocompleteService, appServiceCallback);
         final FormatterService formatterService = new FormatterService(config.getLocale(), clock.getZone());
-        return new AppService(workingTimeService, storage, formatterService, clockService, schedulingService,
+        return new AppService(config, workingTimeService, storage, formatterService, clockService, schedulingService,
                 singleInstanceService, appServiceCallback, activityService, projectService, autocompleteService,
                 new AppPropertiesService(), vacationReportGenerator,
                 projectReportGenerator, pluginManager);
@@ -270,6 +269,11 @@ public class AppService implements Closeable
     public PluginManager pluginManager()
     {
         return pluginManager;
+    }
+
+    public Config config()
+    {
+        return config;
     }
 
     @Override

--- a/logic/src/test/java/org/itsallcode/whiterabbit/logic/service/AppServiceTest.java
+++ b/logic/src/test/java/org/itsallcode/whiterabbit/logic/service/AppServiceTest.java
@@ -117,7 +117,7 @@ class AppServiceTest
     private AppService createAppService(final DelegatingAppServiceCallback appServiceCallback,
             final WorkingTimeService workingTimeService)
     {
-        return new AppService(workingTimeService, storageMock, formatterServiceMock, clockMock,
+        return new AppService(configMock, workingTimeService, storageMock, formatterServiceMock, clockMock,
                 schedulingServiceMock, singleInstanceService, appServiceCallback, activityService, projectServiceMock,
                 autocompleteServiceMock, appPropertiesServiceMock, vacationReportGeneratorMock,
                 projectReportGeneratorMock, pluginManagerMock);


### PR DESCRIPTION
Use [SystemTray](https://github.com/dorkbox/SystemTray) instead of AWT tray by default. You can add optional configuration `system.tray = awt` to keep using AWT.

This fixes the broken system tray in Gnome 3.