### PR TITLE
Fix automatic interruption dialog popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See [Release](https://github.com/itsallcode/white-rabbit/releases/tag/v1.9.0) / 
 
 ### Changes / Bugfixes
 
+* [#241](https://github.com/itsallcode/white-rabbit/pull/241): Fix automatic interruption dialog popup after resume.
 * [#233](https://github.com/itsallcode/white-rabbit/pull/233): Upgrade dependencies, use [Gradle versions catalog](https://docs.gradle.org/current/userguide/platforms.html).
 * [#240](https://github.com/itsallcode/white-rabbit/pull/240): Upgrade dependencies.
 * [#147](https://github.com/itsallcode/white-rabbit/issues/147): Escape key no longer closes the main window.

--- a/jfxui/src/uiTest/java/org/itsallcode/whiterabbit/jfxui/ManualInterruptionTest.java
+++ b/jfxui/src/uiTest/java/org/itsallcode/whiterabbit/jfxui/ManualInterruptionTest.java
@@ -68,6 +68,7 @@ class ManualInterruptionTest extends JavaFxAppUiTestBase
         final DayTable dayTable = app().dayTable();
 
         time().tickMinute();
+        LocalTime dayBeginTime = time().getCurrentTimeMinutes();
         TestUtil.sleepShort();
         final InterruptionDialog interruptionDialog = app().startInterruption();
 
@@ -77,15 +78,40 @@ class ManualInterruptionTest extends JavaFxAppUiTestBase
                 () -> interruptionDialog.assertContent(interruptionStartTime, Duration.ZERO));
 
         time().tickMinute();
+        LocalTime dayEndTime = time().getCurrentTimeMinutes();
         TestUtil.sleepShort();
 
         assertAll(() -> interruptionDialog.assertLabel(interruptionStartTime),
                 () -> interruptionDialog.assertContent(interruptionStartTime.plusMinutes(1), Duration.ofMinutes(1)),
-                () -> dayTable.assertInterruption(currentDayRowIndex, Duration.ZERO));
+                () -> dayTable.assertInterruption(currentDayRowIndex, Duration.ZERO),
+                () -> dayTable.assertBeginAndEnd(currentDayRowIndex, dayBeginTime, dayEndTime));
 
         interruptionDialog.clickAddInterruption();
 
         dayTable.assertInterruption(currentDayRowIndex, Duration.ofMinutes(1));
+    }
+
+    @Test
+    void endTimeUpdatedWhenAutomaticInterruptionDetected()
+    {
+        final int currentDayRowIndex = time().getCurrentDayRowIndex();
+        final DayTable dayTable = app().dayTable();
+
+        time().tickMinute();
+        LocalTime dayBeginTime = time().getCurrentTimeMinutes();
+        TestUtil.sleepShort();
+        final InterruptionDialog interruptionDialog = app().startInterruption();
+
+        Duration sleepTime = Duration.ofMinutes(5);
+        time().addTime(sleepTime);
+
+        LocalTime dayEndTime = time().getCurrentTimeMinutes();
+        TestUtil.sleepShort();
+
+        interruptionDialog.clickAddInterruption();
+
+        assertAll(() -> dayTable.assertInterruption(currentDayRowIndex, sleepTime),
+                () -> dayTable.assertBeginAndEnd(currentDayRowIndex, dayBeginTime, dayEndTime));
     }
 
     @Test

--- a/jfxui/src/uiTest/java/org/itsallcode/whiterabbit/jfxui/testutil/TimeUtil.java
+++ b/jfxui/src/uiTest/java/org/itsallcode/whiterabbit/jfxui/testutil/TimeUtil.java
@@ -162,7 +162,7 @@ public class TimeUtil
         this.updateEveryMinuteRunnable.run();
     }
 
-    private void addTime(final Duration duration)
+    public void addTime(final Duration duration)
     {
         assertThat(duration).isPositive();
         setCurrentTime(clockMock.instant().plus(duration));

--- a/jfxui/src/uiTest/java/org/itsallcode/whiterabbit/jfxui/testutil/model/DayTable.java
+++ b/jfxui/src/uiTest/java/org/itsallcode/whiterabbit/jfxui/testutil/model/DayTable.java
@@ -41,14 +41,14 @@ public class DayTable
 
     public void assertInterruption(int row, Duration expectedInterruption)
     {
-        assertThat(getInterruption(row)).as("interruption").isEqualTo(expectedInterruption);
+        assertThat(getInterruption(row)).as("interruption duration").isEqualTo(expectedInterruption);
     }
 
     public void assertBeginAndEnd(int row, LocalTime begin, LocalTime end)
     {
         assertAll(
-                () -> assertThat(getBegin(row)).as("begin").isEqualTo(begin),
-                () -> assertThat(getEnd(row)).as("end").isEqualTo(end));
+                () -> assertThat(getBegin(row)).as("begin time").isEqualTo(begin),
+                () -> assertThat(getEnd(row)).as("end time").isEqualTo(end));
     }
 
     public void assertDate(int row, LocalDate expectedDate)

--- a/jfxui/src/uiTest/java/org/itsallcode/whiterabbit/jfxui/testutil/model/InterruptionDialog.java
+++ b/jfxui/src/uiTest/java/org/itsallcode/whiterabbit/jfxui/testutil/model/InterruptionDialog.java
@@ -25,14 +25,15 @@ public class InterruptionDialog
     {
         Assertions.assertThat(window).isShowing();
         final Labeled label = robot.from(window.getScene().getRoot()).lookup(".label").queryLabeled();
-        Assertions.assertThat(label).hasText("Interruption started at " + startTime + ". End interruption now?");
+        Assertions.assertThat(label).as("Interruption dialog label")
+                .hasText("Interruption started at " + startTime + ". End interruption now?");
     }
 
     public void assertContent(LocalTime currentTime, Duration interruption)
     {
         Assertions.assertThat(window).isShowing();
         final Labeled label = robot.from(window.getScene().getRoot()).lookup(".content").queryLabeled();
-        Assertions.assertThat(label)
+        Assertions.assertThat(label).as("Interruption dialog content")
                 .hasText("Current time: " + currentTime + ". Add interruption of " + interruption + "?");
     }
 

--- a/logic/src/main/java/org/itsallcode/whiterabbit/logic/service/WorkingTimeService.java
+++ b/logic/src/main/java/org/itsallcode/whiterabbit/logic/service/WorkingTimeService.java
@@ -155,10 +155,9 @@ public class WorkingTimeService
         switch (decision)
         {
         case ADD_INTERRUPTION:
-            addToInterruption(day, interruptionToAdd);
+            addInterruption(day, interruptionToAdd);
             return true;
         case SKIP_INTERRUPTION:
-            // ignore
             return true;
         case STOP_WORKING_FOR_TODAY:
             stopWorkForToday();
@@ -204,7 +203,8 @@ public class WorkingTimeService
     {
         final MonthIndex month = storage.loadOrCreate(YearMonth.from(today));
         final DayRecord day = month.getDay(today);
-        addToInterruption(day, interruption);
+        addInterruption(day, interruption);
+        day.setEnd(clock.getCurrentTime());
         storage.storeMonth(month);
         appServiceCallback.recordUpdated(day);
     }
@@ -222,7 +222,7 @@ public class WorkingTimeService
         resetInterruption();
     }
 
-    private void addToInterruption(final DayRecord day, Duration additionalInterruption)
+    private void addInterruption(final DayRecord day, Duration additionalInterruption)
     {
         final Duration updatedInterruption = day.getInterruption().plus(additionalInterruption);
         LOG.info("Add interruption {} for {}, total interruption: {}", additionalInterruption, day.getDate(),

--- a/logic/src/test/java/org/itsallcode/whiterabbit/logic/service/WorkingTimeServiceTest.java
+++ b/logic/src/test/java/org/itsallcode/whiterabbit/logic/service/WorkingTimeServiceTest.java
@@ -2,6 +2,7 @@ package org.itsallcode.whiterabbit.logic.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -230,5 +231,15 @@ class WorkingTimeServiceTest
         assertThatThrownBy(() -> workingTimeService.startInterruption()).isInstanceOf(IllegalStateException.class)
                 .hasMessage(
                         "An interruption was already started: Interruption [start=2021-11-08T08:00:00Z, currently: PT10M, duration=null]");
+    }
+
+    @Test
+    void addingInterruptionUpdatesEndTime()
+    {
+        when(clockServiceMock.getCurrentTime()).thenReturn(LocalTime.of(10, 30));
+        workingTimeService.addInterruption(TODAY, Duration.ofMinutes(5));
+
+        assertAll(() -> assertThat(day.getEnd()).isEqualTo(LocalTime.of(10, 30)),
+                () -> assertThat(day.getInterruption()).isEqualTo(Duration.ofMinutes(5)));
     }
 }

--- a/plugins/holiday-calculator/build.gradle
+++ b/plugins/holiday-calculator/build.gradle
@@ -3,7 +3,7 @@ dependencies {
         exclude group: 'org.slf4j', module: 'slf4j-api'
     }
     testImplementation libs.bundles.testUtils
-    testRuntimeOnly(libs.log4j.slf4j) {
+    runtimeOnly(libs.log4j.slf4j) {
         exclude group: 'org.apache.logging.log4j', module: 'log4j-api'
         exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
     }


### PR DESCRIPTION
This prevents the automatic interruption dialog from showing after a manual interruption was started and the computer was suspended.
### Steps to reproduce:
1. User starts manual interruption
2. Computer suspends
3. Computer resumes
4. User ends the manual interruption
5. After a short while WhiteRabbit detects an interruption and shows the automatic interruption dialog